### PR TITLE
use @netacea/cloudfront@5.2.44

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,4 @@ dist
 .tern-port
 
 # release zip
-netacea-cloudfront.zip
+netacea-cloudfront*.zip

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@netacea/cloudfront": "^5.2.38"
+        "@netacea/cloudfront": "^5.2.44"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.119",
@@ -285,29 +285,29 @@
       "peer": true
     },
     "node_modules/@netacea/cloudfront": {
-      "version": "5.2.38",
-      "resolved": "https://registry.npmjs.org/@netacea/cloudfront/-/cloudfront-5.2.38.tgz",
-      "integrity": "sha512-grc8BkKeY+uDrOs2kMz078beSY2OYwcxh3iLgGZwk1E/+UgJcyc6Eo5+gd69aoI9XPvnqP/GrulE85TkKG4Ikg==",
+      "version": "5.2.44",
+      "resolved": "https://registry.npmjs.org/@netacea/cloudfront/-/cloudfront-5.2.44.tgz",
+      "integrity": "sha512-SgWsrH7CaMfQ0zIat8HjQ8BSS5XJ7FL7xXmbg0DG5E/phR2RhxKJVi425edF1vKVtmtwCJASYNDPrpjMvvJKGQ==",
       "dependencies": {
-        "@netacea/netaceaintegrationbase": "^2.0.20",
+        "@netacea/netaceaintegrationbase": "^2.0.26",
         "axios": "^0.21.0",
         "jose": "^4.11.2"
       }
     },
     "node_modules/@netacea/kinesisingest": {
-      "version": "1.5.38",
-      "resolved": "https://registry.npmjs.org/@netacea/kinesisingest/-/kinesisingest-1.5.38.tgz",
-      "integrity": "sha512-PWtxi98FHZOVxCZLkTffSAwuOOtBf18g8yv1le2Kq6hgExCCxx68Y/NPAfNdJFrhMGCnowcDQ4W0Q4MxPB2cwA==",
+      "version": "1.5.44",
+      "resolved": "https://registry.npmjs.org/@netacea/kinesisingest/-/kinesisingest-1.5.44.tgz",
+      "integrity": "sha512-Z0s12xVaIsihziXNdFgf8A+8hTjWjgvFmHzE5WLhugZSK2juHbisO8G3AAVTVAzcUgRBVl87zKsvGWR3xwWt9Q==",
       "dependencies": {
         "aws4": "1.11.0"
       }
     },
     "node_modules/@netacea/netaceaintegrationbase": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/@netacea/netaceaintegrationbase/-/netaceaintegrationbase-2.0.20.tgz",
-      "integrity": "sha512-h6jkDKAWc2ZlRy5/b4YSJDhRNZj1wkTovvUGyT40HBDnEHKF7q/J/twcvlp0fZus6PJofe53S63GY8ISYPzSpQ==",
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/@netacea/netaceaintegrationbase/-/netaceaintegrationbase-2.0.26.tgz",
+      "integrity": "sha512-XIP/H8+UpeNuHNR9FX65M791C6De4pJ934Mnk/wronC/HSrqxtBVy1sXaTMoOcFJMZmyvxhL4inD5IXpfUhgoQ==",
       "dependencies": {
-        "@netacea/kinesisingest": "^1.5.38"
+        "@netacea/kinesisingest": "^1.5.44"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Template for CloudFront Lambda@Edge including Netacea worker scripts",
   "main": "./dist/index.js",
   "scripts": {
-    "lint": "npx xo ./src/**/*.ts"
+    "lint": "npx xo ./src/**/*.ts",
+    "upgrade": "npm i @netacea/cloudfront@latest && bash ./scripts/create-zip.sh"
   },
   "repository": {
     "type": "git",
@@ -29,7 +30,7 @@
     "xo": "^0.55.0"
   },
   "dependencies": {
-    "@netacea/cloudfront": "^5.2.38"
+    "@netacea/cloudfront": "^5.2.44"
   },
   "xo": {
     "space": true,


### PR DESCRIPTION
- Use @netacea/cloudfront@5.2.44
- Add `npm run upgrade` script to install latest `@netacea/cloudfront` and build an appropriately named zip file.